### PR TITLE
Don't narrow provenance through &mut + coercion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,23 @@ jobs:
       - name: Lint code
         if: ${{ matrix.rust-toolchain == 'stable' }}
         run: cargo fmt -- --check && cargo clippy --all-features
+
+  miri:
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: miri
+          override: true
+      - name: Run miri with all features
+        run: cargo miri test --all-features
+        env:
+          MIRIFLAGS: -Zmiri-tag-raw-pointers
+
   code_coverage:
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +65,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           components: llvm-tools-preview
+          override: true
       - uses: Swatinem/fucov@v1
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -69,7 +69,7 @@ impl<T> AliasableVec<T> {
 
     #[inline]
     unsafe fn reclaim_as_unique_vec(&mut self) -> UniqueVec<T> {
-        UniqueVec::from_raw_parts(self.ptr.as_mut(), self.len, self.cap)
+        UniqueVec::from_raw_parts(self.ptr.as_ptr(), self.len, self.cap)
     }
 }
 
@@ -152,10 +152,10 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let aliasable = AliasableVec::from_unique(vec![10]);
-        assert_eq!(&*aliasable, &[10]);
+        let aliasable = AliasableVec::from_unique(vec![10, 11]);
+        assert_eq!(&*aliasable, &[10, 11]);
         let unique = AliasableVec::into_unique(aliasable);
-        assert_eq!(&*unique, &[10]);
+        assert_eq!(&*unique, &[10, 11]);
     }
 
     #[test]


### PR DESCRIPTION
The pointer inside AliasableVec's NonNull has provenance over the entire
buffer. Calling .as_mut() on it convert it to a &mut, then passing it to
a function which expects *mut implicitly converts it to the right type,
but the new pointer only has provenance over one item. This caused test
failures under Miri, but only in the string module. Increasing the
length of the allocations in one of the Vec test cases makes the test
failure more clear in the future if the bug comes back.